### PR TITLE
Issue 20 stack dump when using wildcards

### DIFF
--- a/src/Instrumenter.cc
+++ b/src/Instrumenter.cc
@@ -340,7 +340,7 @@ bool Instrumenter::Instrument(Function &Fn, Policy::Direction Dir,
   const bool VarArgs = Fn.isVarArg();
 
   if (VarArgs) {
-    errs() << "Warning: VarArg functions cannot be instrumented.\n";
+    errs() << "Warning: Trying to instrument vararg function " << FnName <<  ". Loom does not support instrumenting vararg functions.\n";
 	return false;
   }
 

--- a/src/Instrumenter.cc
+++ b/src/Instrumenter.cc
@@ -340,7 +340,8 @@ bool Instrumenter::Instrument(Function &Fn, Policy::Direction Dir,
   const bool VarArgs = Fn.isVarArg();
 
   if (VarArgs) {
-    errs() << "Warning: VarArg functions cannot be fully instrumented.\n";
+    errs() << "Warning: VarArg functions cannot be instrumented.\n";
+	return false;
   }
 
   assert(isa<PointerType>(Fn.getType()));

--- a/src/Logger.hh
+++ b/src/Logger.hh
@@ -93,6 +93,9 @@ public:
   /// Types of simple loggers.
   enum class LogType {
 
+	/// The libc printf() function, but treating all u8 pointers as char*
+	UnsafePrintf,
+
     /// The libc printf() function
     Printf,
 

--- a/src/PolicyFile.cc
+++ b/src/PolicyFile.cc
@@ -246,6 +246,7 @@ template <> struct yaml::ScalarEnumerationTraits<SerializationType> {
 template <> struct yaml::ScalarEnumerationTraits<SimpleLogger::LogType> {
   static void enumeration(yaml::IO &io, SimpleLogger::LogType &T) {
     io.enumCase(T, "printf", SimpleLogger::LogType::Printf);
+    io.enumCase(T, "unsafe_printf", SimpleLogger::LogType::UnsafePrintf);
     io.enumCase(T, "xo", SimpleLogger::LogType::Libxo);
     io.enumCase(T, "none", SimpleLogger::LogType::None);
   }

--- a/src/PolicyFile.cc
+++ b/src/PolicyFile.cc
@@ -548,6 +548,12 @@ string PolicyFile::InstrName(const vector<string> &Components) const {
 
 bool PolicyFile::MatchName(std::string instrName, StringRef name) const {
 
+  if (name.find("llvm.") == 0)
+  {
+	  errs() << "Skipping llvm debug function: " << name << "\n";
+	  return false;
+  }
+
   std::string error; // BJK: What to do with Error?
   llvm::Regex nameRegex = llvm::Regex(instrName);
 

--- a/src/PolicyFile.cc
+++ b/src/PolicyFile.cc
@@ -550,7 +550,6 @@ bool PolicyFile::MatchName(std::string instrName, StringRef name) const {
 
   if (name.find("llvm.") == 0)
   {
-	  errs() << "Skipping llvm debug function: " << name << "\n";
 	  return false;
   }
 

--- a/src/PolicyFile.cc
+++ b/src/PolicyFile.cc
@@ -558,6 +558,7 @@ bool PolicyFile::MatchName(std::string instrName, StringRef name) const {
   llvm::Regex nameRegex = llvm::Regex(instrName);
 
   if (!nameRegex.isValid(error)) {
+	errs() << "Invalid regex: " << error << "\n";
     return false;
   }
 

--- a/test/wildcard-function-instrumentation.c
+++ b/test/wildcard-function-instrumentation.c
@@ -1,0 +1,88 @@
+/*
+ * \file  function-instrumentation.c
+ * \brief Tests callee-context function instrumentation.
+ *
+ * Commands for llvm-lit:
+ * RUN: %cpp -DPOLICY_FILE %s > %t.yaml
+ * RUN: %cpp %cflags %s > %t.c
+ * RUN: %clang %cflags -S -emit-llvm %cflags %t.c -o %t.ll
+ * RUN: %loom -S %t.ll -loom-file %t.yaml -o %t.instr.ll
+ * RUN: %filecheck -input-file %t.instr.ll %s
+ * RUN: %llc -filetype=obj %t.instr.ll -o %t.instr.o
+ * RUN: %clang %ldflags %t.instr.o -o %t.instr
+ * RUN: %t.instr > %t.output
+ * RUN: %filecheck -input-file %t.output %s -check-prefix CHECK-OUTPUT
+ */
+
+#if defined (POLICY_FILE)
+
+hook_prefix: __test_hook
+
+logging: printf
+
+block_structure: true
+
+functions:
+    - name: "[a-zA-Z0-9_]+"
+      callee: [ entry, exit ]
+
+#else
+
+#include <stdio.h>
+
+// CHECK: define{{.*}} [[FOO_TYPE:.*]] @foo([[INT:i[0-9]+]]{{.*}}, float{{.*}}, double{{.*}})
+int	foo(int x, float y, double z)
+{
+	// CHECK: call void @[[PREFIX:__test_hook]]_enter_foo([[FOO_ARGS:.*]])
+	printf("foo(%d, %g, %g)\n", x, y, z);
+	return x;
+	// CHECK: call void @[[PREFIX]]_leave_foo([[FOO_TYPE]] [[RETVAL:.*]], [[FOO_ARGS]])
+	// CHECK-NEXT: ret [[FOO_TYPE]] [[RETVAL]]
+}
+
+// CHECK: define{{.*}} [[BAR_TYPE:.*]] @bar([[INT]]{{.*}}, i8*{{.*}})
+float	bar(unsigned int i, const char *s)
+{
+	// CHECK: call void @[[PREFIX]]_enter_bar([[INT]] {{%.*}}, i8* {{%.*}})
+	printf("bar(%d, \"%s\")\n", i, s);
+	// CHECK: call void @[[PREFIX]]_leave_bar
+	return i;
+}
+
+// CHECK: define{{.*}} double @baz()
+double	baz(void)
+{
+	// CHECK: call void @[[PREFIX]]_enter_baz
+	printf("baz()\n");
+	// CHECK: call void @[[PREFIX]]_leave_baz
+	return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+	printf("Hello, world!\n");
+
+	printf("First, we will call foo():\n");
+	foo(1, 2, 3);
+	// CHECK-OUTPUT: enter foo: 1 2{{.*}} 3{{.*}}
+	// CHECK-OUTPUT: foo(1, 2, 3)
+	// CHECK-OUTPUT: leave foo: 1 1 2{{.*}} 3{{.*}}
+
+	printf("Then bar():\n");
+	bar(4, "5");
+	// CHECK-OUTPUT: enter bar: 4 0x{{[0-9a-z]+}}
+	// CHECK-OUTPUT: bar(4, "5")
+	// CHECK-OUTPUT: leave bar
+
+	printf("And finally baz():\n");
+	baz();
+	// CHECK-OUTPUT: enter baz
+	// CHECK-OUTPUT: baz
+	// CHECK-OUTPUT: leave baz
+
+
+	return 0;
+}
+
+#endif /* !POLICY_FILE */


### PR DESCRIPTION
Fix for Issue #20.

Is seems when we try to instrument vararg functions and the llvm debug functions (inserted by the compiler with the prefix "llvm.") the opt pass fails with a stack trace dump. Since we could properly instrument the vararg functions anyway, I have disabled them, outputting an error to indicate that they have not been instrumented.

Since the llvm debug functions are not part of the original code, I decided I would just not instrument them at all. I suspect the end user would not be trying to do so anyway.